### PR TITLE
🐛 修复两个编辑器页面布局问题

### DIFF
--- a/src/components/MonacoEditor.vue
+++ b/src/components/MonacoEditor.vue
@@ -62,7 +62,6 @@ onMounted(async () => {
       language: 'yaml',
       theme: isDark.value ? 'vs-dark' : 'vs',
       wordWrap: 'on',
-      automaticLayout: true,
     })
 
     // @ts-expect-error
@@ -79,6 +78,11 @@ onMounted(async () => {
       ],
     })
 
+    // add resize for editor
+    window.addEventListener('resize', () => {
+      editor.layout()
+    })
+    
     editorStore.setEditor(editor)
 
     editor.onDidChangeModelContent((event) => {

--- a/src/components/MonacoEditor.vue
+++ b/src/components/MonacoEditor.vue
@@ -62,6 +62,7 @@ onMounted(async () => {
       language: 'yaml',
       theme: isDark.value ? 'vs-dark' : 'vs',
       wordWrap: 'on',
+      automaticLayout: true,
     })
 
     // @ts-expect-error

--- a/src/pages/editor.vue
+++ b/src/pages/editor.vue
@@ -51,6 +51,7 @@ onBeforeMount(async () => {
 }
 
 .preview-container {
+  display: flex;
   border: 1px solid var(--wr-border-color);
   padding: 0;
   overflow: hidden;


### PR DESCRIPTION
- 减少窗口高度时左侧预览会下沉
- 右侧编辑器自适应